### PR TITLE
Remove flakiness from tests in OperatorStateBackendTest.java

### DIFF
--- a/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/runtime/state/OperatorStateBackendTest.java
@@ -52,9 +52,12 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -62,6 +65,7 @@ import java.util.concurrent.FutureTask;
 import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -539,6 +543,16 @@ class OperatorStateBackendTest {
         }
     }
 
+    private <T> Iterator<T> sortedIterator(Iterator<T> iterator, Function<T, Object> keyExtractor) {
+        Set<T> set = new TreeSet<T>(Comparator.comparing(x -> (Integer) keyExtractor.apply(x)));
+        iterator.forEachRemaining(set::add);
+        return set.iterator();
+    }
+
+    private <T> Iterator<T> sortedIterator(Iterator<T> iterator) {
+        return sortedIterator(iterator, x -> x);
+    }
+
     @Test
     void testSnapshotRestoreSync() throws Exception {
         AbstractStateBackend abstractStateBackend = new MemoryStateBackend(2 * 4096);
@@ -630,25 +644,26 @@ class OperatorStateBackendTest {
             assertThat(operatorStateBackend.getRegisteredStateNames()).hasSize(3);
             assertThat(operatorStateBackend.getRegisteredBroadcastStateNames()).hasSize(3);
 
-            Iterator<Serializable> it = listState1.get().iterator();
+            Iterator<Serializable> it = sortedIterator(listState1.get().iterator());
             assertThat(it.next()).isEqualTo(42);
             assertThat(it.next()).isEqualTo(4711);
             assertThat(it).isExhausted();
 
-            it = listState2.get().iterator();
+            it = sortedIterator(listState2.get().iterator());
             assertThat(it.next()).isEqualTo(7);
             assertThat(it.next()).isEqualTo(13);
             assertThat(it.next()).isEqualTo(23);
             assertThat(it).isExhausted();
 
-            it = listState3.get().iterator();
+            it = sortedIterator(listState3.get().iterator());
             assertThat(it.next()).isEqualTo(17);
             assertThat(it.next()).isEqualTo(18);
             assertThat(it.next()).isEqualTo(19);
             assertThat(it.next()).isEqualTo(20);
             assertThat(it).isExhausted();
 
-            Iterator<Map.Entry<Serializable, Serializable>> bIt = broadcastState1.iterator();
+            Iterator<Map.Entry<Serializable, Serializable>> bIt =
+                    sortedIterator(broadcastState1.iterator(), x -> x.getKey());
             assertThat(bIt).hasNext();
             Map.Entry<Serializable, Serializable> entry = bIt.next();
             assertThat(entry.getKey()).isEqualTo(1);
@@ -821,20 +836,21 @@ class OperatorStateBackendTest {
             assertThat(it.next().value).isEqualTo(4711);
             assertThat(it).isExhausted();
 
-            it = listState2.get().iterator();
+            it = sortedIterator(listState2.get().iterator(), x -> x.value);
             assertThat(it.next().value).isEqualTo(7);
             assertThat(it.next().value).isEqualTo(13);
             assertThat(it.next().value).isEqualTo(23);
             assertThat(it).isExhausted();
 
-            it = listState3.get().iterator();
+            it = sortedIterator(listState3.get().iterator(), x -> x.value);
             assertThat(it.next().value).isEqualTo(17);
             assertThat(it.next().value).isEqualTo(18);
             assertThat(it.next().value).isEqualTo(19);
             assertThat(it.next().value).isEqualTo(20);
             assertThat(it).isExhausted();
 
-            Iterator<Map.Entry<MutableType, MutableType>> bIt = broadcastState1.iterator();
+            Iterator<Map.Entry<MutableType, MutableType>> bIt =
+                    sortedIterator(broadcastState1.iterator(), x -> x.getKey().value);
             assertThat(bIt).hasNext();
             Map.Entry<MutableType, MutableType> entry = bIt.next();
             assertThat(entry.getKey().value).isOne();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

This PR is similar to the following PR which was accepted:  https://github.com/apache/flink/pull/23298

This PR makes the following tests stable:

```
org.apache.flink.runtime.state.OperatorStateBackendTest#testSnapshotRestoreSync
org.apache.flink.runtime.state.OperatorStateBackendTest#testSnapshotRestoreAsync
```

The tests are currently flaky because the order of elements returned by iterators is non-deterministic.

This PR fixes the flaky tests by making them independent of the order of elements returned by the iterators.

We detected this using the NonDex tool using the following commands:

`mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl flink-runtime -DnondexRuns=10 -Dtest=org.apache.flink.runtime.state.OperatorStateBackendTest#testSnapshotRestoreSync`

`mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -pl flink-runtime -DnondexRuns=10 -Dtest=org.apache.flink.runtime.state.OperatorStateBackendTest#testSnapshotRestoreAsync`

Please see the following Continuous Integration log that shows the flakiness:
https://github.com/asha-boyapati/flink/actions/runs/6193757385

Please see the following Continuous Integration log that shows that the flakiness is fixed by this change:
https://github.com/asha-boyapati/flink/actions/runs/6194044449


## Brief change log

This PR fixes the flaky tests by making them independent of the order of elements returned by the iterators.


## Verifying this change

This change is a trivial rework / code cleanup without any test coverage.

This change only modifies tests slightly and does not change any underlying code.


## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The serializers: (no)
  - The runtime per-record code paths (performance sensitive): (no)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: (no)
  - The S3 file system connector: (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
